### PR TITLE
Update GTK client progress bar colours

### DIFF
--- a/gtk/transmission-ui.css
+++ b/gtk/transmission-ui.css
@@ -1,7 +1,7 @@
-@define-color tr_transfer_down_color steelblue;
-@define-color tr_transfer_up_color forestgreen;
-@define-color tr_transfer_idle_color silver;
-@define-color tr_error_color red;
+@define-color tr_transfer_down_color #5379a9;
+@define-color tr_transfer_up_color #26a955;
+@define-color tr_transfer_idle_color #636363;
+@define-color tr_error_color #ff453a;
 
 .tr-workarea.frame {
     border-left-width: 0;


### PR DESCRIPTION
Another component of some consistency across Transmission clients. This is a look and feel compatibility change that matches #5762. 

Because of the GTK 4 and 3 colour hue diferences, there will be some hue changes in gtkmm 4.11 that will be more reflective of the changes in this pr, but i'm happy with the changes in 3 for now, but marking as draft until gtkmm 4.11 is more readily available on the various distros.

GTK3 w/ Arc-Dark theme

![Screenshot from 2023-08-07 04-49-52-obfuscated](https://github.com/GaryElshaw/transmission/assets/69029666/638eb5d3-c78f-4d97-a4df-d5f573dcbf4d)